### PR TITLE
Add UIView wrapper to provide SwiftUI preview

### DIFF
--- a/Soyeon.xcodeproj/project.pbxproj
+++ b/Soyeon.xcodeproj/project.pbxproj
@@ -227,6 +227,7 @@
 		D8354D7925B4348300C9C531 /* NewAccountInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8354D7825B4348300C9C531 /* NewAccountInteractor.swift */; };
 		D8354D7D25B4348E00C9C531 /* NewAccountRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8354D7C25B4348E00C9C531 /* NewAccountRouter.swift */; };
 		D83760DF262F0CE6002FA23B /* PersonalityType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83760DE262F0CE6002FA23B /* PersonalityType.swift */; };
+		D841ACFE2726D980001EB986 /* SwiftUIPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = D841ACFD2726D980001EB986 /* SwiftUIPreview.swift */; };
 		D8487C6225ED615D00F52B48 /* SwiftyGif in Frameworks */ = {isa = PBXBuildFile; productRef = D8487C6125ED615D00F52B48 /* SwiftyGif */; };
 		D8487C6A25ED64CA00F52B48 /* phase_first.gif in Resources */ = {isa = PBXBuildFile; fileRef = D8487C6925ED64CA00F52B48 /* phase_first.gif */; };
 		D8569C2925D4701000542872 /* Soyeon.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8569C2825D4701000542872 /* Soyeon.swift */; };
@@ -496,6 +497,7 @@
 		D8354D7825B4348300C9C531 /* NewAccountInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewAccountInteractor.swift; sourceTree = "<group>"; };
 		D8354D7C25B4348E00C9C531 /* NewAccountRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewAccountRouter.swift; sourceTree = "<group>"; };
 		D83760DE262F0CE6002FA23B /* PersonalityType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonalityType.swift; sourceTree = "<group>"; };
+		D841ACFD2726D980001EB986 /* SwiftUIPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIPreview.swift; sourceTree = "<group>"; };
 		D8487C6925ED64CA00F52B48 /* phase_first.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = phase_first.gif; sourceTree = "<group>"; };
 		D8569C2825D4701000542872 /* Soyeon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Soyeon.swift; sourceTree = "<group>"; };
 		D8669A8726F85D15005B2A01 /* SoyeonSwitch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoyeonSwitch.swift; sourceTree = "<group>"; };
@@ -1519,6 +1521,7 @@
 				0A9C2A522699D5BF0042692D /* SoyeonPrivateInfo.swift */,
 				0A9C2A592699DFFE0042692D /* DebugHelper.swift */,
 				0A9C2A5B2699EA630042692D /* AppSDKManager.swift */,
+				D841ACFD2726D980001EB986 /* SwiftUIPreview.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -2199,6 +2202,7 @@
 				D828115926F48EE40008D1DF /* DormantApplicationViewController.swift in Sources */,
 				00E295E2266AA05700DB69CE /* Array+.swift in Sources */,
 				009B02AD25B47E9E00753847 /* LoginViewModel.swift in Sources */,
+				D841ACFE2726D980001EB986 /* SwiftUIPreview.swift in Sources */,
 				D828115326F3E8030008D1DF /* AccountStatusView.swift in Sources */,
 				D80DC17725D5016B0053C31A /* PhaseViewController.swift in Sources */,
 				1DCC5C8F260B808700B0736F /* IntroViewController.swift in Sources */,

--- a/Soyeon/Common/SwiftUIPreview.swift
+++ b/Soyeon/Common/SwiftUIPreview.swift
@@ -1,0 +1,58 @@
+//
+//  SwiftUIPreview.swift
+//  Soyeon
+//
+//  Created by junyeong-cho on 2021/10/25.
+//  Copyright © 2021 ludus. All rights reserved.
+//
+
+import SwiftUI
+
+struct Wrap<Wrapped: UIView>: UIViewRepresentable {
+    typealias Updater = (Wrapped, Context) -> Void
+
+    var makeView: () -> Wrapped
+    var update: (Wrapped, Context) -> Void
+
+    init(_ makeView: @escaping @autoclosure () -> Wrapped,
+         updater update: @escaping Updater) {
+        self.makeView = makeView
+        self.update = update
+    }
+
+    func makeUIView(context: Context) -> Wrapped {
+        makeView()
+    }
+
+    func updateUIView(_ view: Wrapped, context: Context) {
+        update(view, context)
+    }
+}
+
+extension Wrap {
+    init(_ makeView: @escaping @autoclosure () -> Wrapped,
+         updater update: @escaping (Wrapped) -> Void) {
+        self.makeView = makeView
+        self.update = { view, _ in update(view) }
+    }
+
+    init(_ makeView: @escaping @autoclosure () -> Wrapped) {
+        self.makeView = makeView
+        self.update = { _, _ in }
+    }
+}
+
+struct SwiftUIPreview: PreviewProvider {
+    static let view: UIView = {
+        let view = UIImageView(image: UIImage(systemName: "person.fill"))
+        view.layer.borderColor = UIColor.gray.cgColor
+        view.layer.borderWidth = 1
+        view.contentMode = .scaleAspectFit
+        return view
+    }()
+    
+    static var previews: some View {
+        Wrap(view)
+            .frame(width: 414, height: 200)
+    }
+}


### PR DESCRIPTION
**SwiftUI Preview를 제공하는 UIView wrapper 추가**

커스텀 뷰(`UIView`)를 프리뷰로 확인할 수 있도록 지원하는 코드를 추가하였습니다.

https://www.swiftbysundell.com/tips/inline-wrapping-of-uikit-or-appkit-views-within-swiftui/

**사용 방법**
1. SwiftUIPreview.swift 파일 클릭
2. Editor > Canvas 가 체크되어 있는지 확인합니다.
3. `SwiftUIPreview` 테스트할 커스텀 뷰 프로퍼티를 추가합니다.
``` 
    static let cell: ProfileCell = {
        let cell = ProfileCell()
        cell.configure(layoutDirection: .horizontal,
                       profileViewModel: .createDummy())
        return cell
    }()

    var body: some View {
        Wrap( `cell`)
    }
```
4. 필요에 따라 `ViewModifier`(`frame`, `foregroundColor`, `border`...)를 사용해 테스트합니다.

```
    static var previews: some View {
        Wrap(cell)
            .frame(width: 414, height: 200)
            .border(.red)
    }
```

**예시**
<img width="800" alt="스크린샷 2021-10-25 오후 10 32 04" src="https://user-images.githubusercontent.com/8664413/138705001-0020f283-756a-4b0f-a0b2-dd44b1b16698.png">


